### PR TITLE
Alter RuleBuilder to support creation of operators from arrays of Propositions.

### DIFF
--- a/src/Ruler/RuleBuilder.php
+++ b/src/Ruler/RuleBuilder.php
@@ -53,25 +53,35 @@ class RuleBuilder implements \ArrayAccess
     /**
      * Create a logical AND operator proposition.
      *
-     * @param Proposition $prop One or more Propositions
+     * @param mixed $prop One or more Propositions
      *
      * @return Operator\LogicalAnd
      */
-    public function logicalAnd(Proposition $prop)
+    public function logicalAnd($prop)
     {
-        return new Operator\LogicalAnd(func_get_args());
+        $args = func_get_args();
+        if (is_array($prop)) {
+            $args = $prop;
+        }
+
+        return new Operator\LogicalAnd($args);
     }
 
     /**
      * Create a logical OR operator proposition.
      *
-     * @param Proposition $prop One or more Propositions
+     * @param mixed $prop One or more Propositions
      *
      * @return Operator\LogicalOr
      */
-    public function logicalOr(Proposition $prop)
+    public function logicalOr($prop)
     {
-        return new Operator\LogicalOr(func_get_args());
+        $args = func_get_args();
+        if (is_array($prop)) {
+            $args = $prop;
+        }
+
+        return new Operator\LogicalOr($args);
     }
 
     /**
@@ -89,13 +99,18 @@ class RuleBuilder implements \ArrayAccess
     /**
      * Create a logical XOR operator proposition.
      *
-     * @param Proposition $prop One or more Propositions
+     * @param mixed $prop One or more Propositions
      *
      * @return Operator\LogicalXor
      */
-    public function logicalXor(Proposition $prop)
+    public function logicalXor($prop)
     {
-        return new Operator\LogicalXor(func_get_args());
+        $args = func_get_args();
+        if (is_array($prop)) {
+            $args = $prop;
+        }
+
+        return new Operator\LogicalXor($args);
     }
 
     /**

--- a/tests/Ruler/Test/RuleBuilderTest.php
+++ b/tests/Ruler/Test/RuleBuilderTest.php
@@ -62,6 +62,25 @@ class RuleBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($rb->logicalXor($true, $false)->evaluate($context));
     }
 
+    public function testLogicalOperatorGenerationOfMultiplePropositions()
+    {
+        $rb      = new RuleBuilder();
+        $context = new Context();
+
+        $true  = new TrueProposition();
+        $false = new FalseProposition();
+
+        $this->assertInstanceOf('Ruler\Operator\LogicalOperator', $rb->logicalAnd(array($true, $false)));
+        $this->assertInstanceOf('Ruler\Operator\LogicalAnd', $rb->logicalAnd(array($true, $false)));
+        $this->assertFalse($rb->logicalAnd(array($true, $false))->evaluate($context));
+
+        $this->assertInstanceOf('Ruler\Operator\LogicalOr', $rb->logicalOr(array($true, $false)));
+        $this->assertTrue($rb->logicalOr(array($true, $false))->evaluate($context));
+
+        $this->assertInstanceOf('Ruler\Operator\LogicalXor', $rb->logicalXor(array($true, $false)));
+        $this->assertTrue($rb->logicalXor(array($true, $false))->evaluate($context));
+    }
+
     public function testRuleCreation()
     {
         $rb      = new RuleBuilder();


### PR DESCRIPTION
The method signature in RuleBuilder was blocking the passing in of arrays as arguments when creating logical operators. In addition, the implementation logic was further complicating this. 
