### PR TITLE
Allow external operator use

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,19 @@ If none of the above are true, it will return the default value for this
 VariableProperty.
 
 
+External Operators
+------------------
+
+Additional operators can be written to fit special per project needs:
+
+```php
+// Assume the namespace is known and ALotGreaterThan operator is implemented
+$rb->registesOperatorNamespace('Ruler\Test\Fixtures');
+$rb->create(
+    $rb['a']->aLotGreaterThan(10);
+);
+```
+
 But that's not all...
 ---------------------
 

--- a/src/Ruler/RuleBuilder.php
+++ b/src/Ruler/RuleBuilder.php
@@ -51,6 +51,20 @@ class RuleBuilder implements \ArrayAccess
     }
 
     /**
+     * Register an operator namespace (Facade to Ruler\Variable::registerNamespace satic method))
+     *
+     * @param string $namespace Operator namespace
+     *
+     * @return RuleBuilder
+     */
+    public function registerNamespace($namespace)
+    {
+        Variable::registerOperatorNamespace($namespace);
+
+        return $this;
+    }
+
+    /**
      * Create a logical AND operator proposition.
      *
      * @param Proposition $prop     Initial Proposition

--- a/tests/Ruler/Test/Fixtures/ALotGreaterThan.php
+++ b/tests/Ruler/Test/Fixtures/ALotGreaterThan.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Ruler package, an OpenSky project.
+ *
+ * (c) 2011 OpenSky Project Inc
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ruler\Test\Fixtures;
+
+use Ruler\Context;
+use Ruler\Value;
+use Ruler\Operator\ComparisonOperator;
+
+/**
+ * An EqualTo comparison operator.
+ *
+ * @author Justin Hileman <justin@shopopensky.com>
+ * @extends ComparisonOperator
+ */
+class ALotGreaterThan extends ComparisonOperator
+{
+    /**
+     * Evaluate whether the given variables are equal in the current Context.
+     *
+     * @param Context $context Context with which to evaluate this ComparisonOperator
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        $value = $this->right->prepareValue($context)->getValue() * 10;
+        return $this->left->prepareValue($context)->greaterThan(new Value($value));
+    }
+}
+

--- a/tests/Ruler/Test/Operator/ExtraOperatorTest.php
+++ b/tests/Ruler/Test/Operator/ExtraOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Ruler\Test\Operator;
+
+use Ruler\Operator;
+use Ruler\Context;
+use Ruler\Variable;
+
+class ExtraOperatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructorAndEvaluation()
+    {
+        $varA    = new Variable('a', 1);
+        $varB    = new Variable('b', 2);
+        $context = new Context();
+
+        $op = new Operator\GreaterThan($varA, $varB);
+        $this->assertFalse($op->evaluate($context));
+
+        $context['a'] = 2;
+        $this->assertFalse($op->evaluate($context));
+
+        $context['a'] = 3;
+        $context['b'] = function() {
+            return 0;
+        };
+        $this->assertTrue($op->evaluate($context));
+    }
+}

--- a/tests/Ruler/Test/VariableTest.php
+++ b/tests/Ruler/Test/VariableTest.php
@@ -173,4 +173,58 @@ class VariableTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($var['baz']));
         $this->assertTrue(isset($var['qux']));
     }
+
+    public function testExternalOperators()
+    {
+        Variable::registerOperatorNamespace('\Ruler\Test\Fixtures');
+        $context = new Context(array('a' => 100));
+        $varA = new Variable('a');
+
+        $this->assertTrue($varA->aLotGreaterThan(1)->evaluate($context));
+
+        $context['a'] = 9;
+        $this->assertFalse($varA->aLotGreaterThan(1)->evaluate($context));
+    }
+
+    /**
+     * @dataProvider testLogicExceptionOnRegisteringOperatorNamespaceProvider
+     *
+     * @expectedException LogicException
+     * @expectedExceptionMessage Namespace argument must be a string
+     */
+    public function testLogicExceptionOnRegisteringOperatorNamespace($input)
+    {
+        Variable::registerOperatorNamespace($input);
+    }
+
+    public function testLogicExceptionOnRegisteringOperatorNamespaceProvider()
+    {
+        return array(
+            array(
+                array('ExceptionRisen')
+            ),
+            array(
+                new \StdClass()
+            ),
+            array(
+                0
+            ),
+            array(
+                null
+            )
+        );
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Did not manage to instantiate extra operator "aLotBiggerThan"
+     */
+    public function testLogicExceptionOnUnknownOperator()
+    {
+        Variable::registerOperatorNamespace('\Ruler\Test\Fixtures');
+        $varA = new Variable('a');
+
+        $varA->aLotBiggerThan(1);
+    }
+
 }


### PR DESCRIPTION
Allowing to implement specific operators using Ruler API and store them in a specific namespace. Implementation can surely be improved.

Maybe I didn't undersand well how to bring my porcelain :)
