### PR TITLE
Remove dependency on Pimple.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "homepage": "https://github.com/bobthecow/Ruler",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0",
-        "pimple/pimple": "1.0.*"
+        "php": ">=5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/Ruler/Context.php
+++ b/src/Ruler/Context.php
@@ -3,10 +3,25 @@
 /*
  * This file is part of the Ruler package, an OpenSky project.
  *
- * (c) 2011 OpenSky Project Inc
+ * Copyright (c) 2009 Fabien Potencier
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 namespace Ruler;
@@ -16,10 +31,22 @@ namespace Ruler;
  *
  * The Context contains facts with which to evaluate a Rule or other Proposition.
  *
+ * Derived from Pimple, by Fabien Potencier:
+ *
+ * https://github.com/fabpot/Pimple
+ *
+ * @author Fabien Potencier
  * @author Justin Hileman <justin@justinhileman.info>
  */
-class Context extends \Pimple
+class Context implements \ArrayAccess
 {
+    private $keys   = array();
+    private $values = array();
+    private $frozen = array();
+    private $raw    = array();
+
+    private $shared;
+    private $protected;
 
     /**
      * Context constructor.
@@ -31,6 +58,185 @@ class Context extends \Pimple
      */
     public function __construct(array $values = array())
     {
-        parent::__construct($values);
+        $this->shared    = new \SplObjectStorage;
+        $this->protected = new \SplObjectStorage;
+
+        foreach ($values as $key => $value) {
+            $this->offsetSet($key, $value);
+        }
+    }
+
+    /**
+     * Check if a fact is defined.
+     *
+     * @param string $name The unique name for the fact
+     *
+     * @return boolean
+     */
+    public function offsetExists($name)
+    {
+        return isset($this->keys[$name]);
+    }
+
+    /**
+     * Get the value of a fact.
+     *
+     * @param string $name The unique name for the fact
+     *
+     * @return mixed The resolved value of the fact
+     *
+     * @throws InvalidArgumentException if the name is not defined
+     */
+    public function offsetGet($name)
+    {
+        if (!$this->offsetExists($name)) {
+            throw new \InvalidArgumentException(sprintf('Fact "%s" is not defined.', $name));
+        }
+
+        $value = $this->values[$name];
+
+        // If the value is already frozen, or if it's not callable, or if it's protected, return the raw value
+        if (isset($this->frozen[$name]) || !is_object($value) || $this->protected->contains($value) || !$this->isCallable($value)) {
+            return $value;
+        }
+
+        // If this is a shared value, resolve, freeze, and return the result
+        if ($this->shared->contains($value)) {
+            $this->frozen[$name] = true;
+            $this->raw[$name]    = $value;
+
+            return $this->values[$name] = $value($this);
+        }
+
+        // Otherwise, resolve and return the result
+        return $value($this);
+    }
+
+    /**
+     * Set a fact name and value.
+     *
+     * A fact will be lazily evaluated if it is a Closure or invokable object.
+     * To define a fact as a literal callable, use Context::protect.
+     *
+     * @param string $name  The unique name for the fact
+     * @param mixed  $value The value or a closure to lazily define the value
+     *
+     * @throws RuntimeException if a frozen fact overridden
+     */
+    public function offsetSet($name, $value)
+    {
+        if (isset($this->frozen[$name])) {
+            throw new \RuntimeException(sprintf('Cannot override frozen fact "%s".', $name));
+        }
+
+        $this->keys[$name]   = true;
+        $this->values[$name] = $value;
+    }
+
+    /**
+     * Unset a fact
+     *
+     * @param string $name The unique name for the fact
+     */
+    public function offsetUnset($name)
+    {
+        if ($this->offsetExists($name)) {
+            $value = $this->values[$name];
+
+            if (is_object($value)) {
+                $this->shared->detach($value);
+                $this->protected->detach($value);
+            }
+
+            unset($this->keys[$name], $this->values[$name], $this->frozen[$name], $this->raw[$name]);
+        }
+    }
+
+    /**
+     * Define a fact as "shared". This lazily evaluates and stores the result
+     * of the callable for the scope of this Context instance.
+     *
+     * @param callable $callable A fact callable to share
+     *
+     * @return callable The passed callable
+     *
+     * @throws InvalidArgumentException if the callable is not a Closure or invokable object
+     */
+    public function share($callable)
+    {
+        if (!$this->isCallable($callable)) {
+            throw new \InvalidArgumentException('Value is not a Closure or invokable object.');
+        }
+
+        $this->shared->attach($callable);
+
+        return $callable;
+    }
+
+    /**
+     * Protect a callable from being interpreted as a lazy fact definition.
+     *
+     * This is useful when you want to store a callable as the literal value of
+     * a fact.
+     *
+     * @param callable $callable A callable to protect from being evaluated
+     *
+     * @return callable The passed callable
+     *
+     * @throws InvalidArgumentException if the callable is not a Closure or invokable object
+     */
+    public function protect($callable)
+    {
+        if (!$this->isCallable($callable)) {
+            throw new \InvalidArgumentException('Callable is not a Closure or invokable object.');
+        }
+
+        $this->protected->attach($callable);
+
+        return $callable;
+    }
+
+    /**
+     * Get a fact or the closure defining a fact.
+     *
+     * @param string $name The unique name for the fact
+     *
+     * @return mixed The value of the fact or the closure defining the fact
+     *
+     * @throws InvalidArgumentException if the name is not defined
+     */
+    public function raw($name)
+    {
+        if (!$this->offsetExists($name)) {
+            throw new \InvalidArgumentException(sprintf('Fact "%s" is not defined.', $name));
+        }
+
+        if (isset($this->frozen[$name])) {
+            return $this->raw[$name];
+        }
+
+        return $this->values[$name];
+    }
+
+    /**
+     * Get all defined fact names.
+     *
+     * @return array An array of fact names
+     */
+    public function keys()
+    {
+        return array_keys($this->keys);
+    }
+
+    /**
+     * Check whether a value is a Closure or invokable object.
+     *
+     * @param mixed $callable
+     *
+     * @return boolean
+     */
+    protected function isCallable($callable)
+    {
+        return is_object($callable) && is_callable($callable);
     }
 }

--- a/tests/Ruler/Test/ContextTest.php
+++ b/tests/Ruler/Test/ContextTest.php
@@ -1,9 +1,43 @@
 <?php
 
+/*
+ * Copyright (c) 2009 Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 namespace Ruler\Test;
 
 use Ruler\Context;
+use Ruler\Test\Fixtures\Invokable;
+use Ruler\Test\Fixtures\Fact;
 
+/**
+ * Ruler Context test
+ *
+ * Derived from Pimple, by Fabien Potencier:
+ *
+ * https://github.com/fabpot/Pimple
+ *
+ * @author Igor Wiedler <igor@wiedler.ch>
+ * @author Justin Hileman <justin@justinhileman.info>
+ */
 class ContextTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
@@ -26,5 +60,242 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(isset($context['delicious']));
         $this->assertTrue($context['delicious']);
+    }
+
+    public function testWithString()
+    {
+        $context = new Context();
+        $context['param'] = 'value';
+
+        $this->assertEquals('value', $context['param']);
+    }
+
+    public function testWithClosure()
+    {
+        $context = new Context();
+        $context['fact'] = function () {
+            return new Fact();
+        };
+
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $context['fact']);
+    }
+
+    public function testFactsShouldBeDifferent()
+    {
+        $context = new Context();
+        $context['fact'] = function () {
+            return new Fact();
+        };
+
+        $factOne = $context['fact'];
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $factOne);
+
+        $factTwo = $context['fact'];
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $factTwo);
+
+        $this->assertNotSame($factOne, $factTwo);
+    }
+
+    public function testShouldPassContextAsParameter()
+    {
+        $context = new Context();
+        $context['fact'] = function () {
+            return new Fact();
+        };
+        $context['context'] = function ($context) {
+            return $context;
+        };
+
+        $this->assertNotSame($context, $context['fact']);
+        $this->assertSame($context, $context['context']);
+    }
+
+    public function testIsset()
+    {
+        $context = new Context();
+        $context['param'] = 'value';
+        $context['fact'] = function () {
+            return new Fact();
+        };
+
+        $context['null'] = null;
+
+        $this->assertTrue(isset($context['param']));
+        $this->assertTrue(isset($context['fact']));
+        $this->assertTrue(isset($context['null']));
+        $this->assertFalse(isset($context['non_existent']));
+    }
+
+    public function testConstructorInjection()
+    {
+        $params = array("param" => "value");
+        $context = new Context($params);
+
+        $this->assertSame($params['param'], $context['param']);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Fact "foo" is not defined.
+     */
+    public function testOffsetGetValidatesKeyIsPresent()
+    {
+        $context = new Context();
+        echo $context['foo'];
+    }
+
+    public function testOffsetGetHonorsNullValues()
+    {
+        $context = new Context();
+        $context['foo'] = null;
+        $this->assertNull($context['foo']);
+    }
+
+    public function testUnset()
+    {
+        $context = new Context();
+        $context['param'] = 'value';
+        $context['fact'] = function () {
+            return new Fact();
+        };
+
+        unset($context['param'], $context['fact']);
+        $this->assertFalse(isset($context['param']));
+        $this->assertFalse(isset($context['fact']));
+    }
+
+    /**
+     * @dataProvider factDefinitionProvider
+     */
+    public function testShare($fact)
+    {
+        $context = new Context();
+        $context['shared_fact'] = $context->share($fact);
+
+        $factOne = $context['shared_fact'];
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $factOne);
+
+        $factTwo = $context['shared_fact'];
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $factTwo);
+
+        $this->assertSame($factOne, $factTwo);
+    }
+
+    /**
+     * @dataProvider factDefinitionProvider
+     */
+    public function testProtect($fact)
+    {
+        $context = new Context();
+        $context['protected'] = $context->protect($fact);
+
+        $this->assertSame($fact, $context['protected']);
+    }
+
+    public function testGlobalFunctionNameAsParameterValue()
+    {
+        $context = new Context();
+        $context['global_function'] = 'strlen';
+        $this->assertSame('strlen', $context['global_function']);
+    }
+
+    public function testRaw()
+    {
+        $context = new Context();
+        $context['fact'] = $definition = function () { return 'foo'; };
+        $this->assertSame($definition, $context->raw('fact'));
+    }
+
+    public function testRawHonorsNullValues()
+    {
+        $context = new Context();
+        $context['foo'] = null;
+        $this->assertNull($context->raw('foo'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Fact "foo" is not defined.
+     */
+    public function testRawValidatesKeyIsPresent()
+    {
+        $context = new Context();
+        $context->raw('foo');
+    }
+
+    public function testKeys()
+    {
+        $context = new Context();
+        $context['foo'] = 123;
+        $context['bar'] = 123;
+
+        $this->assertEquals(array('foo', 'bar'), $context->keys());
+    }
+
+    /** @test */
+    public function settingAnInvokableObjectShouldTreatItAsFactory()
+    {
+        $context = new Context();
+        $context['invokable'] = new Invokable();
+
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $context['invokable']);
+    }
+
+    /** @test */
+    public function settingNonInvokableObjectShouldTreatItAsParameter()
+    {
+        $context = new Context();
+        $context['non_invokable'] = new Fact();
+
+        $this->assertInstanceOf('Ruler\Test\Fixtures\Fact', $context['non_invokable']);
+    }
+
+    /**
+     * @dataProvider badFactDefinitionProvider
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Value is not a Closure or invokable object.
+     */
+    public function testShareFailsForInvalidFactDefinitions($fact)
+    {
+        $context = new Context();
+        $context->share($fact);
+    }
+
+    /**
+     * @dataProvider badFactDefinitionProvider
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Callable is not a Closure or invokable object.
+     */
+    public function testProtectFailsForInvalidFactDefinitions($fact)
+    {
+        $context = new Context();
+        $context->protect($fact);
+    }
+
+    /**
+     * Provider for invalid fact definitions
+     */
+    public function badFactDefinitionProvider()
+    {
+        return array(
+          array(123),
+          array(new Fact())
+        );
+    }
+
+    /**
+     * Provider for fact definitions
+     */
+    public function factDefinitionProvider()
+    {
+        return array(
+            array(function ($value) {
+                $fact = new Fact();
+                $fact->value = $value;
+
+                return $fact;
+            }),
+            array(new Invokable())
+        );
     }
 }

--- a/tests/Ruler/Test/Fixtures/Fact.php
+++ b/tests/Ruler/Test/Fixtures/Fact.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ruler\Test\Fixtures;
+
+class Fact
+{
+    public function __construct($value = null)
+    {
+        if ($value !== null) {
+            $this->value = $value;
+        }
+    }
+}

--- a/tests/Ruler/Test/Fixtures/Invokable.php
+++ b/tests/Ruler/Test/Fixtures/Invokable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ruler\Test\Fixtures;
+
+use Ruler\Test\Fixtures\Fact;
+
+class Invokable
+{
+    public function __invoke($value = null)
+    {
+        return new Fact($value);
+    }
+}


### PR DESCRIPTION
Pimple 2.x has changed to shared-services-by-default, a decision that’s awesome for a DIC, but not as awesome for a general purpose lazy value bucket like we’re using Pimple for. Since this will likely cause problems with apps which use both Ruler and Pimple, I have removed the Pimple dependency and implemented the Pimple 1.x API directly on Context — using Pimple 2.x-flavored code :)

The extend() method has not been ported to Context, as that seems like a side effect of using a DIC as a base class, more than an explicit feature for the Context. But I’m happy to be proven wrong if someone really needs it.

cc: @jwage @ludicruz Thoughts?
