### PR TITLE
Proposition and VariableOperand implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea/

--- a/src/Ruler/BaseProposition.php
+++ b/src/Ruler/BaseProposition.php
@@ -12,11 +12,15 @@
 namespace Ruler;
 
 /**
- * The Proposition interface represents a propositional statement.
+ * Aggregation of Proposition and VariableOperand interface.
+ *
+ * An attempt to make (refactor) all propositional operators and variables stick
+ * to the same contract. After all everything could be a proposition (even Variables)
+ * in Ruler.
  *
  * @author Justin Hileman <justin@justinhileman.info>
  */
-interface Proposition extends BaseProposition
+interface BaseProposition
 {
 
     /**
@@ -27,4 +31,11 @@ interface Proposition extends BaseProposition
      * @return boolean
      */
     public function evaluate(Context $context);
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context);
 }

--- a/src/Ruler/Operator/Addition.php
+++ b/src/Ruler/Operator/Addition.php
@@ -31,6 +31,19 @@ class Addition extends VariableOperator implements VariableOperand
         return new Value($left->prepareValue($context)->add($right->prepareValue($context)));
     }
 
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/Ceil.php
+++ b/src/Ruler/Operator/Ceil.php
@@ -34,4 +34,18 @@ class Ceil extends VariableOperator implements VariableOperand
     {
         return static::UNARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
+
 }

--- a/src/Ruler/Operator/Ceil.php
+++ b/src/Ruler/Operator/Ceil.php
@@ -46,6 +46,4 @@ class Ceil extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
-
 }

--- a/src/Ruler/Operator/Complement.php
+++ b/src/Ruler/Operator/Complement.php
@@ -54,5 +54,4 @@ class Complement extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Complement.php
+++ b/src/Ruler/Operator/Complement.php
@@ -42,4 +42,17 @@ class Complement extends VariableOperator implements VariableOperand
     {
         return static::MULTIPLE;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Contains.php
+++ b/src/Ruler/Operator/Contains.php
@@ -13,6 +13,7 @@ namespace Ruler\Operator;
 
 use Ruler\Context;
 use Ruler\Proposition;
+use Ruler\Value;
 use Ruler\VariableOperand;
 
 /**
@@ -47,6 +48,17 @@ class Contains extends VariableOperator implements Proposition
             return $left->stringContains($right->prepareValue($context));
         }
     }
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
 
     protected function getOperandCardinality()
     {

--- a/src/Ruler/Operator/ContainsSubset.php
+++ b/src/Ruler/Operator/ContainsSubset.php
@@ -37,6 +37,16 @@ class ContainsSubset extends VariableOperator implements Proposition
             ->containsSubset($right->prepareValue($context)->getSet());
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/Division.php
+++ b/src/Ruler/Operator/Division.php
@@ -35,4 +35,17 @@ class Division extends VariableOperator implements VariableOperand
     {
         return static::BINARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Division.php
+++ b/src/Ruler/Operator/Division.php
@@ -47,5 +47,4 @@ class Division extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/DoesNotContainSubset.php
+++ b/src/Ruler/Operator/DoesNotContainSubset.php
@@ -37,6 +37,16 @@ class DoesNotContainSubset extends VariableOperator implements Proposition
             ->containsSubset($right->prepareValue($context)->getSet()) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/EndsWith.php
+++ b/src/Ruler/Operator/EndsWith.php
@@ -36,6 +36,16 @@ class EndsWith extends VariableOperator implements Proposition
         return $left->prepareValue($context)->endsWith($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/EndsWithInsensitive.php
+++ b/src/Ruler/Operator/EndsWithInsensitive.php
@@ -36,6 +36,16 @@ class EndsWithInsensitive extends VariableOperator implements Proposition
         return $left->prepareValue($context)->endsWith($right->prepareValue($context), true);
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/EqualTo.php
+++ b/src/Ruler/Operator/EqualTo.php
@@ -36,6 +36,16 @@ class EqualTo extends VariableOperator implements Proposition
         return $left->prepareValue($context)->equalTo($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/Exponentiate.php
+++ b/src/Ruler/Operator/Exponentiate.php
@@ -35,4 +35,17 @@ class Exponentiate extends VariableOperator implements VariableOperand
     {
         return static::BINARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Exponentiate.php
+++ b/src/Ruler/Operator/Exponentiate.php
@@ -47,5 +47,4 @@ class Exponentiate extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Floor.php
+++ b/src/Ruler/Operator/Floor.php
@@ -46,5 +46,4 @@ class Floor extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Floor.php
+++ b/src/Ruler/Operator/Floor.php
@@ -34,4 +34,17 @@ class Floor extends VariableOperator implements VariableOperand
     {
         return static::UNARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/GreaterThan.php
+++ b/src/Ruler/Operator/GreaterThan.php
@@ -36,6 +36,16 @@ class GreaterThan extends VariableOperator implements Proposition
         return $left->prepareValue($context)->greaterThan($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/GreaterThanOrEqualTo.php
+++ b/src/Ruler/Operator/GreaterThanOrEqualTo.php
@@ -36,6 +36,16 @@ class GreaterThanOrEqualTo extends VariableOperator implements Proposition
         return $left->prepareValue($context)->lessThan($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/Intersect.php
+++ b/src/Ruler/Operator/Intersect.php
@@ -54,5 +54,4 @@ class Intersect extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Intersect.php
+++ b/src/Ruler/Operator/Intersect.php
@@ -42,4 +42,17 @@ class Intersect extends VariableOperator implements VariableOperand
     {
         return static::MULTIPLE;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/LessThan.php
+++ b/src/Ruler/Operator/LessThan.php
@@ -36,6 +36,16 @@ class LessThan extends VariableOperator implements Proposition
         return $left->prepareValue($context)->lessThan($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/LessThanOrEqualTo.php
+++ b/src/Ruler/Operator/LessThanOrEqualTo.php
@@ -36,6 +36,16 @@ class LessThanOrEqualTo extends VariableOperator implements Proposition
         return $left->prepareValue($context)->greaterThan($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/LogicalAnd.php
+++ b/src/Ruler/Operator/LogicalAnd.php
@@ -30,6 +30,11 @@ class LogicalAnd extends LogicalOperator
     {
         /** @var Proposition $operand */
         foreach ($this->getOperands() as $operand) {
+            if($operand->evaluate($context) instanceof Value
+                && $operand->evaluate($context)->getValue() === false) {
+                return false;
+            }
+
             if ($operand->evaluate($context) === false) {
                 return false;
             }

--- a/src/Ruler/Operator/LogicalAnd.php
+++ b/src/Ruler/Operator/LogicalAnd.php
@@ -30,7 +30,7 @@ class LogicalAnd extends LogicalOperator
     {
         /** @var Proposition $operand */
         foreach ($this->getOperands() as $operand) {
-            if($operand->evaluate($context) instanceof Value
+            if ($operand->evaluate($context) instanceof Value
                 && $operand->evaluate($context)->getValue() === false) {
                 return false;
             }

--- a/src/Ruler/Operator/LogicalNot.php
+++ b/src/Ruler/Operator/LogicalNot.php
@@ -31,6 +31,10 @@ class LogicalNot extends LogicalOperator
         /** @var Proposition $operand */
         list($operand) = $this->getOperands();
 
+        if($operand->evaluate($context) instanceof Value) {
+            return !$operand->evaluate($context)->getValue();
+        }
+
         return !$operand->evaluate($context);
     }
 

--- a/src/Ruler/Operator/LogicalNot.php
+++ b/src/Ruler/Operator/LogicalNot.php
@@ -31,7 +31,7 @@ class LogicalNot extends LogicalOperator
         /** @var Proposition $operand */
         list($operand) = $this->getOperands();
 
-        if($operand->evaluate($context) instanceof Value) {
+        if ($operand->evaluate($context) instanceof Value) {
             return !$operand->evaluate($context)->getValue();
         }
 

--- a/src/Ruler/Operator/LogicalOperator.php
+++ b/src/Ruler/Operator/LogicalOperator.php
@@ -42,12 +42,10 @@ abstract class LogicalOperator extends PropositionOperator implements Propositio
      */
     public function prepareValue(Context $context)
     {
-        if(($value = $this->evaluate($context)) instanceof Value) {
+        if (($value = $this->evaluate($context)) instanceof Value) {
             return $value;
         }
 
         return new Value($value);
     }
-
-
 }

--- a/src/Ruler/Operator/LogicalOperator.php
+++ b/src/Ruler/Operator/LogicalOperator.php
@@ -11,14 +11,17 @@
 
 namespace Ruler\Operator;
 
+use Ruler\Context;
 use Ruler\Proposition;
+use Ruler\Value;
+use Ruler\VariableOperand;
 
 /**
  * Logical operator base class
  *
  * @author Justin Hileman <justin@justinhileman.info>
  */
-abstract class LogicalOperator extends PropositionOperator implements Proposition
+abstract class LogicalOperator extends PropositionOperator implements Proposition, VariableOperand
 {
     /**
      * array of propositions
@@ -31,4 +34,20 @@ abstract class LogicalOperator extends PropositionOperator implements Propositio
             $this->addOperand($operand);
         }
     }
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        if(($value = $this->evaluate($context)) instanceof Value) {
+            return $value;
+        }
+
+        return new Value($value);
+    }
+
+
 }

--- a/src/Ruler/Operator/LogicalOr.php
+++ b/src/Ruler/Operator/LogicalOr.php
@@ -31,7 +31,7 @@ class LogicalOr extends LogicalOperator
     {
         /** @var Proposition $operand */
         foreach ($this->getOperands() as $operand) {
-            if($operand->evaluate($context) instanceof Value
+            if ($operand->evaluate($context) instanceof Value
                 && $operand->evaluate($context)->getValue() === true) {
                 return true;
             }

--- a/src/Ruler/Operator/LogicalOr.php
+++ b/src/Ruler/Operator/LogicalOr.php
@@ -13,6 +13,7 @@ namespace Ruler\Operator;
 
 use Ruler\Context;
 use Ruler\Proposition;
+use Ruler\Value;
 
 /**
  * A logical OR operator.
@@ -30,6 +31,11 @@ class LogicalOr extends LogicalOperator
     {
         /** @var Proposition $operand */
         foreach ($this->getOperands() as $operand) {
+            if($operand->evaluate($context) instanceof Value
+                && $operand->evaluate($context)->getValue() === true) {
+                return true;
+            }
+
             if ($operand->evaluate($context) === true) {
                 return true;
             }

--- a/src/Ruler/Operator/LogicalXor.php
+++ b/src/Ruler/Operator/LogicalXor.php
@@ -31,9 +31,8 @@ class LogicalXor extends LogicalOperator
         $true = 0;
         /** @var Proposition $operand */
         foreach ($this->getOperands() as $operand) {
-            if($operand->evaluate($context) instanceof Value
+            if ($operand->evaluate($context) instanceof Value
                 && true === $operand->evaluate($context)->getValue()) {
-
                 if (++$true > 1) {
                     return false;
                 }

--- a/src/Ruler/Operator/LogicalXor.php
+++ b/src/Ruler/Operator/LogicalXor.php
@@ -31,6 +31,14 @@ class LogicalXor extends LogicalOperator
         $true = 0;
         /** @var Proposition $operand */
         foreach ($this->getOperands() as $operand) {
+            if($operand->evaluate($context) instanceof Value
+                && true === $operand->evaluate($context)->getValue()) {
+
+                if (++$true > 1) {
+                    return false;
+                }
+            }
+
             if (true === $operand->evaluate($context)) {
                 if (++$true > 1) {
                     return false;

--- a/src/Ruler/Operator/Max.php
+++ b/src/Ruler/Operator/Max.php
@@ -46,5 +46,4 @@ class Max extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Max.php
+++ b/src/Ruler/Operator/Max.php
@@ -34,4 +34,17 @@ class Max extends VariableOperator implements VariableOperand
     {
         return static::UNARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Min.php
+++ b/src/Ruler/Operator/Min.php
@@ -34,4 +34,17 @@ class Min extends VariableOperator implements VariableOperand
     {
         return static::UNARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Min.php
+++ b/src/Ruler/Operator/Min.php
@@ -46,5 +46,4 @@ class Min extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Modulo.php
+++ b/src/Ruler/Operator/Modulo.php
@@ -35,4 +35,17 @@ class Modulo extends VariableOperator implements VariableOperand
     {
         return static::BINARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Modulo.php
+++ b/src/Ruler/Operator/Modulo.php
@@ -47,5 +47,4 @@ class Modulo extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Multiplication.php
+++ b/src/Ruler/Operator/Multiplication.php
@@ -47,5 +47,4 @@ class Multiplication extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Multiplication.php
+++ b/src/Ruler/Operator/Multiplication.php
@@ -35,4 +35,17 @@ class Multiplication extends VariableOperator implements VariableOperand
     {
         return static::BINARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/Negation.php
+++ b/src/Ruler/Operator/Negation.php
@@ -46,5 +46,4 @@ class Negation extends VariableOperator implements VariableOperand
     {
         return $this->prepareValue($context);
     }
-
 }

--- a/src/Ruler/Operator/Negation.php
+++ b/src/Ruler/Operator/Negation.php
@@ -34,4 +34,17 @@ class Negation extends VariableOperator implements VariableOperand
     {
         return static::UNARY;
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
 }

--- a/src/Ruler/Operator/NotEqualTo.php
+++ b/src/Ruler/Operator/NotEqualTo.php
@@ -36,6 +36,16 @@ class NotEqualTo extends VariableOperator implements Proposition
         return $left->prepareValue($context)->equalTo($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/NotSameAs.php
+++ b/src/Ruler/Operator/NotSameAs.php
@@ -36,6 +36,16 @@ class NotSameAs extends VariableOperator implements Proposition
         return $left->prepareValue($context)->sameAs($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/SameAs.php
+++ b/src/Ruler/Operator/SameAs.php
@@ -36,6 +36,16 @@ class SameAs extends VariableOperator implements Proposition
         return $left->prepareValue($context)->sameAs($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/SetContains.php
+++ b/src/Ruler/Operator/SetContains.php
@@ -36,6 +36,16 @@ class SetContains extends VariableOperator implements Proposition
         return $left->prepareValue($context)->getSet()->setContains($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/SetDoesNotContain.php
+++ b/src/Ruler/Operator/SetDoesNotContain.php
@@ -36,6 +36,16 @@ class SetDoesNotContain extends VariableOperator implements Proposition
         return $left->prepareValue($context)->getSet()->setContains($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/StartsWith.php
+++ b/src/Ruler/Operator/StartsWith.php
@@ -36,6 +36,16 @@ class StartsWith extends VariableOperator implements Proposition
         return $left->prepareValue($context)->startsWith($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/StartsWithInsensitive.php
+++ b/src/Ruler/Operator/StartsWithInsensitive.php
@@ -36,6 +36,16 @@ class StartsWithInsensitive extends VariableOperator implements Proposition
         return $left->prepareValue($context)->startsWith($right->prepareValue($context), true);
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/StringContains.php
+++ b/src/Ruler/Operator/StringContains.php
@@ -36,6 +36,16 @@ class StringContains extends VariableOperator implements Proposition
         return $left->prepareValue($context)->stringContains($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/StringContainsInsensitive.php
+++ b/src/Ruler/Operator/StringContainsInsensitive.php
@@ -36,6 +36,16 @@ class StringContainsInsensitive extends VariableOperator implements Proposition
         return $left->prepareValue($context)->stringContainsInsensitive($right->prepareValue($context));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/StringDoesNotContain.php
+++ b/src/Ruler/Operator/StringDoesNotContain.php
@@ -36,6 +36,16 @@ class StringDoesNotContain extends VariableOperator implements Proposition
         return $left->prepareValue($context)->stringContains($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/StringDoesNotContainInsensitive.php
+++ b/src/Ruler/Operator/StringDoesNotContainInsensitive.php
@@ -36,6 +36,16 @@ class StringDoesNotContainInsensitive extends VariableOperator implements Propos
         return $left->prepareValue($context)->stringContainsInsensitive($right->prepareValue($context)) === false;
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/Subtraction.php
+++ b/src/Ruler/Operator/Subtraction.php
@@ -31,6 +31,19 @@ class Subtraction extends VariableOperator implements VariableOperand
         return new Value($left->prepareValue($context)->subtract($right->prepareValue($context)));
     }
 
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/SymmetricDifference.php
+++ b/src/Ruler/Operator/SymmetricDifference.php
@@ -32,6 +32,19 @@ class SymmetricDifference extends VariableOperator implements VariableOperand
             ->symmetricDifference($right->prepareValue($context)->getSet());
     }
 
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/src/Ruler/Operator/Union.php
+++ b/src/Ruler/Operator/Union.php
@@ -34,6 +34,18 @@ class Union extends VariableOperator implements VariableOperand
         return $union;
     }
 
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context);
+    }
+
     protected function getOperandCardinality()
     {
         return static::MULTIPLE;

--- a/src/Ruler/Rule.php
+++ b/src/Ruler/Rule.php
@@ -19,7 +19,7 @@ namespace Ruler;
  *
  * @author Justin Hileman <justin@justinhileman.info>
  */
-class Rule implements Proposition
+class Rule implements Proposition, VariableOperand
 {
     protected $condition;
     protected $action;
@@ -47,6 +47,21 @@ class Rule implements Proposition
     {
         return $this->condition->evaluate($context);
     }
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        if(($value = $this->evaluate($context)) instanceof Value) {
+            return $value;
+        }
+
+        return new Value($value);
+    }
+
 
     /**
      * Execute the Rule with the given Context.

--- a/src/Ruler/Rule.php
+++ b/src/Ruler/Rule.php
@@ -55,7 +55,7 @@ class Rule implements Proposition, VariableOperand
      */
     public function prepareValue(Context $context)
     {
-        if(($value = $this->evaluate($context)) instanceof Value) {
+        if (($value = $this->evaluate($context)) instanceof Value) {
             return $value;
         }
 

--- a/src/Ruler/Variable.php
+++ b/src/Ruler/Variable.php
@@ -98,6 +98,4 @@ class Variable implements VariableOperand, Proposition
     {
         return $this->prepareValue($context)->getValue();
     }
-
-
 }

--- a/src/Ruler/Variable.php
+++ b/src/Ruler/Variable.php
@@ -20,7 +20,7 @@ namespace Ruler;
  *
  * @author Justin Hileman <justin@justinhileman.info>
  */
-class Variable implements VariableOperand
+class Variable implements VariableOperand, Proposition
 {
     private $name;
     private $value;
@@ -86,4 +86,18 @@ class Variable implements VariableOperand
 
         return ($value instanceof Value) ? $value : new Value($value);
     }
+
+    /**
+     * Evaluate the Proposition with the given Context.
+     *
+     * @param Context $context Context with which to evaluate this Proposition
+     *
+     * @return boolean
+     */
+    public function evaluate(Context $context)
+    {
+        return $this->prepareValue($context)->getValue();
+    }
+
+
 }

--- a/src/Ruler/VariableOperand.php
+++ b/src/Ruler/VariableOperand.php
@@ -14,7 +14,7 @@ namespace Ruler;
 /**
  * @author Jordan Raub <jordan@raub.me>
  */
-interface VariableOperand
+interface VariableOperand extends BaseProposition
 {
     /**
      * @param Context $context

--- a/tests/Ruler/Test/Fixtures/ALotGreaterThan.php
+++ b/tests/Ruler/Test/Fixtures/ALotGreaterThan.php
@@ -41,6 +41,16 @@ class ALotGreaterThan extends VariableOperator implements Proposition
         return $left->prepareValue($context)->greaterThan(new Value($value));
     }
 
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
     protected function getOperandCardinality()
     {
         return static::BINARY;

--- a/tests/Ruler/Test/Fixtures/CallbackProposition.php
+++ b/tests/Ruler/Test/Fixtures/CallbackProposition.php
@@ -4,6 +4,7 @@ namespace Ruler\Test\Fixtures;
 
 use Ruler\Proposition;
 use Ruler\Context;
+use Ruler\Value;
 
 class CallbackProposition implements Proposition
 {
@@ -22,4 +23,16 @@ class CallbackProposition implements Proposition
     {
         return call_user_func($this->callback, $context);
     }
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value($this->evaluate($context));
+    }
+
+
 }

--- a/tests/Ruler/Test/Fixtures/FalseProposition.php
+++ b/tests/Ruler/Test/Fixtures/FalseProposition.php
@@ -4,6 +4,7 @@ namespace Ruler\Test\Fixtures;
 
 use Ruler\Proposition;
 use Ruler\Context;
+use Ruler\Value;
 
 class FalseProposition implements Proposition
 {
@@ -11,4 +12,16 @@ class FalseProposition implements Proposition
     {
         return false;
     }
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value(false);
+    }
+
+
 }

--- a/tests/Ruler/Test/Fixtures/TrueProposition.php
+++ b/tests/Ruler/Test/Fixtures/TrueProposition.php
@@ -4,6 +4,7 @@ namespace Ruler\Test\Fixtures;
 
 use Ruler\Proposition;
 use Ruler\Context;
+use Ruler\Value;
 
 class TrueProposition implements Proposition
 {
@@ -11,4 +12,16 @@ class TrueProposition implements Proposition
     {
         return true;
     }
+
+    /**
+     * @param Context $context
+     *
+     * @return Value
+     */
+    public function prepareValue(Context $context)
+    {
+        return new Value(true);
+    }
+
+
 }

--- a/tests/Ruler/Test/Functional/RulerPropositionTest.php
+++ b/tests/Ruler/Test/Functional/RulerPropositionTest.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace Ruler\Test\Functional;
+
+use Ruler\RuleBuilder;
+use Ruler\Context;
+
+use Ruler\Operator\EqualTo;
+
+/**
+ * Class RulerPropositionTest
+ *
+ * When implementing both interfaces contracts, Proposition and VariableOperand, we can
+ * just use the Variable instance as a Proposition and can have VariableOperators
+ * passed as Proposition arguments to logical operators. Notice the lack of use:
+ * $rb['q']->equalTo() in order to pass a proposition to logical operators.
+ *
+ * @package Ruler\Test\Functional
+ */
+class RulerPropositionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Testing rules like this:
+     *
+     * $rule = $rb->create(
+     *      new \Ruler\Operator\EqualTo(
+     *          $rb->logicalNot(
+     *              $rb->logicalAnd(
+     *                  $rb['p'],
+     *                  $rb['q']
+     *              )
+     *          ),
+     *          $rb->logicalOr(
+     *              $rb->logicalNot(
+     *                  $rb['p']
+     *              ),
+     *              $rb->logicalNot(
+     *                  $rb['q']
+     *              )
+     *          )
+     *      )
+     * );
+     *
+     * @dataProvider truthTableTwo
+     */
+    public function testDeMorgan($p, $q)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q'));
+
+        $left = $rb->logicalNot(
+            $rb->logicalAnd(
+                $rb['p'],
+                $rb['q']
+            )
+        );
+
+        $right = $rb->logicalOr(
+            $rb->logicalNot(
+                $rb['p']
+            ),
+            $rb->logicalNot(
+                $rb['q']
+            )
+        );
+
+        $this->assertEquals(
+            $left->evaluate($context),
+            $right->evaluate($context)
+        );
+
+        $rule = $rb->create(
+            new EqualTo($left, $right)
+        );
+
+        $this->assertTrue($rule->evaluate($context));
+    }
+
+    /**
+     * @dataProvider truthTableTwo
+     */
+    public function testDeMorganTwo($p, $q)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q'));
+
+        $left = $rb->create(
+            $rb->logicalNot(
+                $rb->logicalOr(
+                    $rb['p'],
+                    $rb['q']
+                )
+            )
+        );
+
+        $right = $rb->create(
+            $rb->logicalAnd(
+                $rb->logicalNot(
+                    $rb['p']
+                ),
+                $rb->logicalNot(
+                    $rb['q']
+                )
+            )
+        );
+
+        $this->assertEquals(
+            $left->evaluate($context),
+            $right->evaluate($context)
+        );
+
+        $rule = $rb->create(
+            new EqualTo($left, $right)
+        );
+
+        $this->assertTrue($rule->evaluate($context));
+    }
+
+    /**
+     * @dataProvider truthTableTwo
+     */
+    public function testCommutation($p, $q)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalOr(
+                    $rb['p'],
+                    $rb['q']
+                )
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalOr(
+                    $rb['q'],
+                    $rb['p']
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableTwo
+     */
+    public function testCommutationTwo($p, $q)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb['p'],
+                    $rb['q']
+                )
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb['q'],
+                    $rb['p']
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableThree
+     */
+    public function testAssociation($p, $q, $r)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q', 'r'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalOr(
+                    $rb['p'],
+                    $rb->logicalOr(
+                        $rb['q'],
+                        $rb['r']
+                    )
+                )
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalOr(
+                    $rb->logicalOr(
+                        $rb['p'],
+                        $rb['q']
+                    ),
+                    $rb['r']
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableThree
+     */
+    public function testAssociationTwo($p, $q, $r)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q', 'r'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb['p'],
+                    $rb->logicalAnd(
+                        $rb['q'],
+                        $rb['r']
+                    )
+                )
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb->logicalAnd(
+                        $rb['p'],
+                        $rb['q']
+                    ),
+                    $rb['r']
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableThree
+     */
+    public function testDistribution($p, $q, $r)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q', 'r'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb['p'],
+                    $rb->logicalOr(
+                        $rb['q'],
+                        $rb['r']
+                    )
+                )
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalOr(
+                    $rb->logicalAnd(
+                        $rb['p'],
+                        $rb['q']
+                    ),
+                    $rb->logicalAnd(
+                        $rb['p'],
+                        $rb['r']
+                    )
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableThree
+     */
+    public function testDistributionTwo($p, $q, $r)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p', 'q', 'r'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalOr(
+                    $rb['p'],
+                    $rb->logicalAnd(
+                        $rb['q'],
+                        $rb['r']
+                    )
+                )
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb->logicalOr(
+                        $rb['p'],
+                        $rb['q']
+                    ),
+                    $rb->logicalOr(
+                        $rb['p'],
+                        $rb['r']
+                    )
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableOne
+     */
+    public function testDoubleNegation($p)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p'));
+        $this->assertEquals(
+            $rb->create(
+                $rb['p']
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalNot(
+                    $rb->logicalNot(
+                        $rb['p']
+                    )
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableOne
+     */
+    public function testTautology($p)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p'));
+        $this->assertEquals(
+            $rb->create(
+                $rb['p']
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalOr(
+                    $rb['p'],
+                    $rb['p']
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableOne
+     */
+    public function testTautologyTwo($p)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p'));
+        $this->assertEquals(
+            $rb->create(
+                $rb['p']
+            )->evaluate($context),
+            $rb->create(
+                $rb->logicalAnd(
+                    $rb['p'],
+                    $rb['p']
+                )
+            )->evaluate($context)
+        );
+    }
+
+    /**
+     * @dataProvider truthTableOne
+     */
+    public function testExcludedMiddle($p)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalOr(
+                    $rb['p'],
+                    $rb->logicalNot(
+                        $rb['p']
+                    )
+                )
+            )->evaluate($context),
+            true
+        );
+    }
+
+    /**
+     * @dataProvider truthTableOne
+     */
+    public function testNonContradiction($p)
+    {
+        $rb = new RuleBuilder();
+        $context = new Context(compact('p'));
+        $this->assertEquals(
+            $rb->create(
+                $rb->logicalNot(
+                    $rb->logicalAnd(
+                        $rb['p'],
+                        $rb->logicalNot(
+                            $rb['p']
+                        )
+                    )
+                )
+            )->evaluate($context),
+            true
+        );
+    }
+
+    public function truthTableOne()
+    {
+        return array(
+            array(true),
+            array(false),
+        );
+    }
+
+    public function truthTableTwo()
+    {
+        return array(
+            array(true,  true),
+            array(true,  false),
+            array(false, true),
+            array(false, false),
+        );
+    }
+
+    public function truthTableThree()
+    {
+        return array(
+            array(true,  true,  true),
+            array(true,  true,  false),
+            array(true,  false, true),
+            array(true,  false, false),
+            array(false, true,  true),
+            array(false, true,  false),
+            array(false, false, true),
+            array(false, false, false),
+        );
+    }
+}


### PR DESCRIPTION
Hello, 

would you please take a look to this. The result desired is to have rules like those in 

```
Test/Functional/RulerPropositionTest.php. 
```

Please notice that the main goal is to be able to have `Proposition` instances behaves like `VariableOperand` instances and viceversa, in my opinion this allow some more freedom when building the rules because you can pass along to each one to another without raising any exception on invalid arguments. My concern is: Am I forcing the architecture with this?

Also a thing I don't like is that I created a parent interface and aggregate both Proposition, VariableOperand into it, in order to have all operators implementing same methods, I thought to unify all interface implementations in one like all of them just being `Proposition` but then I did not see how only one `execute` method would do the job for all operators and it was to much of re-factoring to take into account.

It would be nice to have this checked and eventually included in the mainstream.

Thanks and best regards,
David
