### PR TITLE
Limit the Rulter\Test namespace to the development environment only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,13 @@
     },
     "autoload": {
         "psr-0": {
-            "Ruler": "src",
+            "Ruler": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
             "Ruler\\Test": "tests"
-            }
+        }
     },
     "authors": [
         {


### PR DESCRIPTION
Limit the Rulter\Test namespace to the development environment only