### PR TITLE
Fix warnings in php7.2 by initialising the operands array

### DIFF
--- a/src/Ruler/Operator.php
+++ b/src/Ruler/Operator.php
@@ -20,7 +20,7 @@ abstract class Operator
     const BINARY = 'BINARY';
     const MULTIPLE = 'MULTIPLE';
 
-    protected $operands;
+    protected $operands = [];
 
     /**
      * @param array $operands


### PR DESCRIPTION
This fixes #55 by correctly initialising the operands array