### PR TITLE
PHPUnit security vulnerability

### DIFF
--- a/.github/workflows/hhvm.yml
+++ b/.github/workflows/hhvm.yml
@@ -1,0 +1,45 @@
+name: Unit Tests HHVM
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  testing:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        hhvm: ['hhvm/hhvm:3.30.0']
+
+    container: ${{ matrix.hhvm }}
+
+    steps:
+    - name: Install composer
+      shell: bash
+      run: |
+        php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+        php -r "if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+        php composer-setup.php
+        php -r "unlink('composer-setup.php');"
+        mv composer.phar /bin/composer
+
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-${{ matrix.hhvm }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.hhvm }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: hhvm vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,9 +32,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-${{ matrix.php-version }}-php-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-php-
+          ${{ runner.os }}-${{ matrix.php-version }}-php-
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,43 @@
+name: Unit Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2']
+        php-version: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.4']
 
     steps:
     - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 | ^5.5 | ^6.5"
+        "phpunit/phpunit": "4.8.35 | ^5.6.3 | ^6.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi,

lately I did start receiving some alert from Github about used version of PHPUnit and code injection. I know it is about a development dependency which **should not be used in production**, still I think it is good to have this sorted out, for the sake of peace of mind.

This PR does:
* Include Github Action workflow files for pipelines. Travis.org is no more since some time ago.
* Enforce usage of patched PHPUnit versions
* Include version 7.4 of php to the build matrix
* Test HHVM against latest version published [with php support](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html)