### PR TITLE
Update setup-php action version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@2.37.2
       with:
         php-version: ${{ matrix.php-version }}
 


### PR DESCRIPTION
Avoid vulnerability found on versions lower than 2.37.1 due to a vulnerable version of composer. Using 2.37.2 now.

This is just for the github actions pipeline.

Thanks!